### PR TITLE
added scripts section to setup.py

### DIFF
--- a/hicsuntdracones/hicmatrix.py
+++ b/hicsuntdracones/hicmatrix.py
@@ -40,7 +40,7 @@ class HiCMatrix:
         self.number_of_bins = self.hic_matrix_df.shape[0]
         self.chromosomes = self._chromosomes()
 
-        
+
     def _check_file(self):
         # TODO
         # check if file contains "HiCMatrix" and "Regions"
@@ -60,7 +60,7 @@ class HiCMatrix:
             sys.stderr.write("Missing column 'Regions'."
                              "Is this really a HiC matrix in Homer format?")
             sys.exit(1)
-    
+
     def save(self, output_hic_matrix_file):
         self.hic_matrix_df.to_csv(output_hic_matrix_file, sep="\t",
                                   index=False)
@@ -146,9 +146,9 @@ class HiCMatrix:
         numerator_matrix_values = self.matrix_values() + pseudocount
         denominator_matrix_values = denominator_matrix.matrix_values() + pseudocount
         diff_matrix = numerator_matrix_values / denominator_matrix_values
-        return pd.concat([self.hic_matrix_df[[
-            "HiCMatrix", "Regions"]], diff_matrix],
-                         axis=1, join_axes=[self.hic_matrix_df.index])
+        concat_df = pd.concat([self.hic_matrix_df[[
+            "HiCMatrix", "Regions"]], diff_matrix],axis=1)
+        return concat_df.reindex(self.hic_matrix_df.index)
 
     def heatmap(self, vmin=None, vmax=None, output_prefix=None,
                 by_chrom=False, rotate=False, output_pdf=False,output_png=False, png_dpi=600,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [
 
 setup(
     name='hicsuntdracones',
-    version='0.1.0',
+    version='0.2.0',
     description="A HiC matrix tool",
     long_description=readme + '\n\n' + history,
     author="Konrad Förstner",
@@ -54,4 +54,5 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     setup_requires=setup_requirements,
+    scripts=['bin/hicsd']
 )


### PR DESCRIPTION
The `setup.py` was missing the scripts keyword, thus the executable `bin/hicsd` was not being installed correctly when running `setup.py`. The version number in this file was also still on 0.1.0, even though the tag on github says 0.2.0, creating confusing output during the installation process.